### PR TITLE
Add initial text to DID Document section.

### DIFF
--- a/index.html
+++ b/index.html
@@ -522,7 +522,7 @@ DID Document
       </h2>
      <p>
 A DID Document is the resource that is associated with a
-<a>decentralized identifier</a>. The DID Document typically contains a
+<a>decentralized identifier</a>. The DID Document typically expresses
 list of public keys and services that can be used to interact with an entity
 that is associated with a DID.
       </p>

--- a/index.html
+++ b/index.html
@@ -518,13 +518,18 @@ use with other Internet-based identifiers.
     </section>
     <section>
       <h2>
-Document
+DID Document
       </h2>
+     <p>
+A DID Document is the resource that is associated with a
+<a>decentralized identifier</a>. The DID Document typically contains a
+list of public keys and services that can be used to interact with an entity
+that is associated with a DID.
+      </p>
+
       <p>
-A DID resolves to a <a>DID Document</a>. This is the concrete serialization of
-the data model, according to a particular syntax (see
-<a href="#did-document-syntax"></a>). The <a>DID Document</a> contains attributes
-or claims about the <a href="#did-subject"></a>, and the DID itself is
+A DID Document is serialized according to a particular syntax (see
+<a href="#did-document-syntax"></a>). The DID itself is
 contained in the <code>id</code> property.
       </p>
       <p>

--- a/index.html
+++ b/index.html
@@ -521,14 +521,14 @@ use with other Internet-based identifiers.
 DID Document
       </h2>
      <p>
-A DID Document is the resource that is associated with a <a>decentralized
-identifier</a>. The DID Document typically expresses verification methods (such
-as public keys) and services that can be used to interact with a DID
-controller.
+A <a>DID Document</a> is the resource that is associated with a <a>decentralized
+identifier</a>. The <a>DID Document</a> typically expresses verification methods (such
+as public keys) and services that can be used to interact with a
+<a>DID controller</a>.
       </p>
 
       <p>
-A DID Document is serialized according to a particular syntax (see
+A <a>DID Document</a> is serialized according to a particular syntax (see
 <a href="#did-document-syntax"></a>). The DID itself is
 contained in the <code>id</code> property.
       </p>

--- a/index.html
+++ b/index.html
@@ -523,7 +523,7 @@ DID Document
      <p>
 A DID Document is the resource that is associated with a
 <a>decentralized identifier</a>. The DID Document typically expresses
-list of public keys and services that can be used to interact with an entity
+verification methods (such as public keys) and services that can be used to interact with an entity
 that is associated with a DID.
       </p>
 

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
     },
     includePermalinks: false,
 
-  
+
     // if this is a LCWD, uncomment and set the end of its review period
     // lcEnd: "2009-08-05",
 
@@ -521,10 +521,10 @@ use with other Internet-based identifiers.
 DID Document
       </h2>
      <p>
-A DID Document is the resource that is associated with a
-<a>decentralized identifier</a>. The DID Document typically expresses
-verification methods (such as public keys) and services that can be used to interact with an entity
-that is associated with a DID.
+A DID Document is the resource that is associated with a <a>decentralized
+identifier</a>. The DID Document typically expresses verification methods (such
+as public keys) and services that can be used to interact with a DID
+controller.
       </p>
 
       <p>
@@ -2155,7 +2155,7 @@ inclusion are documented in the [[DID-METHOD-REGISTRY]].
 
   </section>
 
-  <section class='normative'> 
+  <section class='normative'>
     <h1>
 DID Resolvers
     </h1>


### PR DESCRIPTION
Add initial content to the data model section on DID Documents.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec/pull/30.html" title="Last updated on Oct 10, 2019, 1:07 AM UTC (68cc190)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec/30/3df087e...68cc190.html" title="Last updated on Oct 10, 2019, 1:07 AM UTC (68cc190)">Diff</a>