### PR TITLE
Fix grammar in DID path and fragment sentence.

### DIFF
--- a/terms.html
+++ b/terms.html
@@ -103,8 +103,8 @@ compatible graph-based data formats.
 
   <dd>
 The portion of a <a>DID URL</a> that follows the first hash
-sign character (<code>#</code>). A DID fragment uses the same syntax as a URI
-fragment.
+sign character (<code>#</code>). DID fragment syntax is identical to URI
+fragment syntax.
   </dd>
 
 
@@ -122,7 +122,7 @@ documents</a> are written and updated.
 
   <dd>
 The portion of a <a>DID URL</a> that begins with and includes the first forward
-slash character (<code>/</code>). A DID path uses the identical syntax as a URI path.
+slash character (<code>/</code>). DID path syntax is identical to URI path syntax.
   </dd>
 
 


### PR DESCRIPTION
To be consistent with f87f7ed71b9f99cf7ac7ecfaf2e5ec190fb76a7c.