### PR TITLE
Admin changes in the respec setting

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,8 @@
   var respecConfig = {
         wgPublicList: "public-did-wg",
         wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/117488/status",
+        wg: "Decentralized Identifier Working Group",
+        wgURI: "https://www.w3.org/2019/did-wg/",
 
     // specification status (e.g., WD, LCWD, NOTE, etc.). If in doubt use ED.
     specStatus: "ED",
@@ -50,28 +52,28 @@
     includePermalinks: false,
 
 
-    // if this is a LCWD, uncomment and set the end of its review period
-    // lcEnd: "2009-08-05",
-
     // editors, add as many as you like
     // only "name" is required
     editors: [{
         name: "Drummond Reed",
         url: "https://www.linkedin.com/in/drummondreed/",
         company: "Evernym",
-        companyURL: "https://evernym.com/"
+        companyURL: "https://evernym.com/",
+        w3cid: 3096
       },
       {
         name: "Manu Sporny",
         url: "http://manu.sporny.org/",
         company: "Digital Bazaar",
-        companyURL: "https://digitalbazaar.com/"
+        companyURL: "https://digitalbazaar.com/",
+        w3cid: 41758
       },
       {
         name: "Markus Sabadello",
         url: "https://www.linkedin.com/in/markus-sabadello-353a0821",
         company: "Danube Tech",
-        companyURL: "https://danubetech.com/"
+        companyURL: "https://danubetech.com/",
+        w3cid: 46729
       }
     ],
 
@@ -82,25 +84,29 @@
         name: "Drummond Reed",
         url: "https://www.linkedin.com/in/drummondreed/",
         company: "Evernym",
-        companyURL: "https://evernym.com/"
+        companyURL: "https://evernym.com/",
+        w3cid: 3096
       },
       {
         name: "Manu Sporny",
         url: "http://manu.sporny.org/",
         company: "Digital Bazaar",
-        companyURL: "https://digitalbazaar.com/"
+        companyURL: "https://digitalbazaar.com/",
+        w3cid: 41758
       },
       {
         name: "Dave Longley",
         url: "",
         company: "Digital Bazaar",
-        companyURL: "https://digitalbazaar.com/"
+        companyURL: "https://digitalbazaar.com/",
+        w3cid: 48025
       },
       {
         name: "Christopher Allen",
         url: "https://www.linkedin.com/in/christophera",
         company: "Blockchain Commons",
-        companyURL: "https://www.BlockchainCommons.com"
+        companyURL: "https://www.BlockchainCommons.com",
+        w3cid: 85560
       },
       {
         name: "Ryan Grant",
@@ -112,7 +118,8 @@
         name: "Markus Sabadello",
         url: "https://www.linkedin.com/in/markus-sabadello-353a0821",
         company: "Danube Tech",
-        companyURL: "https://danubetech.com/"
+        companyURL: "https://danubetech.com/",
+        w3cid: 46729
       }
     ]
     };


### PR DESCRIPTION
- Added the `w3cid` entry for each editor and author (this is required by Echidna)
- Added the `wg` and `wgURI` fields (necessary for the respec boilerplate, see https://github.com/w3c/did-spec/pull/87#issuecomment-545344978)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec/pull/89.html" title="Last updated on Oct 23, 2019, 10:17 AM UTC (84ecb95)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec/89/b1d8c84...84ecb95.html" title="Last updated on Oct 23, 2019, 10:17 AM UTC (84ecb95)">Diff</a>